### PR TITLE
Feat: Playwright을 사용한 웹 동작 구현

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/main.kt
+++ b/desktopApp/src/jvmMain/kotlin/main.kt
@@ -1,11 +1,63 @@
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import com.vowserclient.shared.browserautomation.BrowserAutomationService
+import com.vowser.client.websocket.BrowserControlWebSocketClient
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 fun main() = application {
     Napier.base(DebugAntilog())
+
+    // BrowserAutomationService 초기화
+    // application 스코프 내에서 suspend 함수를 호출하기 위해 launch 블록 사용
+    CoroutineScope(Dispatchers.IO).launch { // Dispatchers.IO는 Playwright 초기화에 적합
+        try {
+            BrowserAutomationService.initialize()
+            Napier.i("BrowserAutomationService 초기화 완료.", tag = "AppInit")
+        } catch (e: Exception) {
+            Napier.e("BrowserAutomationService 초기화 실패: ${e.message}", e, tag = "AppInit")
+            // 초기화 실패 시 애플리케이션 종료 또는 다른 오류 처리 로직 추가
+            exitApplication() // Compose 애플리케이션 종료
+        }
+    }
+
+    // WebSocket 클라이언트 인스턴스 생성
+    val webSocketClient = BrowserControlWebSocketClient()
+
+    // WebSocket 비동기적 연결 시도
+    CoroutineScope(Dispatchers.IO).launch {
+        try {
+            webSocketClient.connect()
+            Napier.i("WebSocket 클라이언트 연결 완료.", tag = "WebSocket")
+        } catch (e: Exception) {
+            Napier.e("Failed to connect to WebSocket: ${e.message}", e, tag = "WebSocket")
+            webSocketClient.reconnect()
+        }
+    }
+
     Window(onCloseRequest = ::exitApplication) {
         App()
     }
+
+    // 애플리케이션 종료 시 리소스 정리
+    Runtime.getRuntime().addShutdownHook(Thread {
+        runBlocking { // shutdown hook 스레드 내에서 suspend 함수를 호출하기 위해 runBlocking 사용
+            try {
+                BrowserAutomationService.cleanup()
+                Napier.i("BrowserAutomationService 정리 완료.", tag = "AppShutdown")
+            } catch (e: Exception) {
+                Napier.e("BrowserAutomationService 정리 중 오류 발생: ${e.message}", e, tag = "AppShutdown")
+            }
+            try {
+                webSocketClient.close()
+                Napier.i("WebSocket 클라이언트 종료 완료.", tag = "AppShutdown")
+            } catch (e: Exception) {
+                Napier.e("WebSocket 클라이언트 종료 중 오류 발생: ${e.message}", e, tag = "AppShutdown")
+            }
+        }
+    })
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
                 implementation(compose.desktop.common)
 
                 // Playwright
-                implementation("com.microsoft.playwright:playwright:1.40.0")
+                implementation("com.microsoft.playwright:playwright:1.52.0")
             }
         }
     }
@@ -64,7 +64,6 @@ android {
 
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
-    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         minSdk = (findProperty("android.minSdk") as String).toInt()

--- a/shared/src/commonMain/kotlin/com/vowser/client/websocket/dto/BrowserCommand.kt
+++ b/shared/src/commonMain/kotlin/com/vowser/client/websocket/dto/BrowserCommand.kt
@@ -1,0 +1,10 @@
+package com.vowser.client.websocket.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class BrowserCommand {
+    @Serializable data object GoBack : BrowserCommand()
+    @Serializable data object GoForward : BrowserCommand()
+    @Serializable data class Navigate(val url: String) : BrowserCommand()
+}

--- a/shared/src/commonMain/kotlin/com/vowserclient/shared/browserautomation/BrowserAutomationBridge.kt
+++ b/shared/src/commonMain/kotlin/com/vowserclient/shared/browserautomation/BrowserAutomationBridge.kt
@@ -1,0 +1,7 @@
+package com.vowserclient.shared.browserautomation
+
+expect object BrowserAutomationBridge {
+    suspend fun goBackInBrowser()
+    suspend fun goForwardInBrowser()
+    suspend fun navigateInBrowser(url: String)
+}

--- a/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/BrowserAutomationBridgeActual.kt
+++ b/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/BrowserAutomationBridgeActual.kt
@@ -1,0 +1,20 @@
+package com.vowserclient.shared.browserautomation
+
+import io.github.aakira.napier.Napier
+
+actual object BrowserAutomationBridge {
+    actual suspend fun goBackInBrowser() {
+        Napier.i { "Desktop: BrowserAutomationBridge.goBackInBrowser() 호출됨" }
+        BrowserAutomationService.goBack()
+    }
+
+    actual suspend fun goForwardInBrowser() {
+        Napier.i { "Desktop: BrowserAutomationBridge.goForwardInBrowser() 호출됨" }
+        BrowserAutomationService.goForward()
+    }
+
+    actual suspend fun navigateInBrowser(url: String) {
+        Napier.i { "Desktop: BrowserAutomationBridge.navigateInBrowser($url) 호출됨" }
+        BrowserAutomationService.navigate(url)
+    }
+}

--- a/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/BrowserAutomationService.kt
+++ b/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/BrowserAutomationService.kt
@@ -1,0 +1,186 @@
+package com.vowserclient.shared.browserautomation
+
+import com.microsoft.playwright.Browser
+import com.microsoft.playwright.BrowserType
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.Playwright
+import com.microsoft.playwright.PlaywrightException
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+// 간단한 테스트를 위해서 싱글톤으로 구현 -> object 사용
+object BrowserAutomationService {
+
+    private lateinit var playwright: Playwright
+    private lateinit var browser: Browser
+    private lateinit var page: Page
+    private val mutex = Mutex()
+
+    suspend fun initialize() = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (!::playwright.isInitialized) {
+                Napier.i("BrowserAutomationService: Initializing Playwright...", tag = "BrowserAutomationService")
+                try {
+                    playwright = Playwright.create()
+                    browser = playwright.chromium().launch(
+                        BrowserType.LaunchOptions()
+                            .setHeadless(false)
+                            .setChannel("chrome")
+                    )
+                    page = browser.newPage()
+                    page.waitForLoadState()
+                    // TODO 초기화 실패 시 예외 발생
+                    Napier.i("BrowserAutomationService: Playwright initialized successfully.", tag = "BrowserAutomationService")
+                } catch (e: Exception) {
+                    Napier.e("BrowserAutomationService: Failed to initialize Playwright: ${e.message}", e, tag = "BrowserAutomationService")
+                    throw e
+                }
+            }
+        }
+    }
+
+    suspend fun cleanup() = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (::playwright.isInitialized) {
+                Napier.i("BrowserAutomationService: Cleaning up Playwright resources.", tag = "BrowserAutomationService")
+                try {
+                    page.close()
+                    browser.close()
+                    playwright.close()
+                } catch (e: Exception) {
+                    Napier.e("BrowserAutomationService: Failed to clean up Playwright resources: ${e.message}", e, tag = "BrowserAutomationService")
+                }
+            }
+        }
+    }
+
+    suspend fun navigate(url: String) = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (!::page.isInitialized) {
+                Napier.e("BrowserAutomationService: Page is not initialized. Cannot navigate to $url", tag = "BrowserAutomationService")
+                return@withContext
+            }
+            Napier.i { "BrowserAutomationService: Navigating to $url" }
+            try {
+                page.navigate(url)
+                Napier.i { "BrowserAutomationService: Navigation to $url completed." }
+            } catch (e: PlaywrightException) {
+                Napier.e("BrowserAutomationService: Navigation failed to $url: ${e.message}", e, tag = "BrowserAutomationService")
+            } catch (e: Exception) {
+                Napier.e("BrowserAutomationService: Unexpected error during navigation to $url: ${e.message}", e, tag = "BrowserAutomationService")
+            }
+        }
+    }
+
+    suspend fun goBack() = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (!::page.isInitialized) {
+                Napier.e("BrowserAutomationService: Page is not initialized. Cannot go back.", tag = "BrowserAutomationService")
+                return@withContext
+            }
+            Napier.i { "BrowserAutomationService: Going back" }
+            try {
+                val response = page.goBack()
+                if (response == null) {
+                    Napier.w { "BrowserAutomationService: No previous page to go back to." }
+                } else {
+                    page.waitForLoadState()
+                    Napier.i { "BrowserAutomationService: Go back completed." }
+                }
+            } catch (e: PlaywrightException) {
+                Napier.e("BrowserAutomationService: Go back failed: ${e.message}", e, tag = "BrowserAutomationService")
+            } catch (e: Exception) {
+                Napier.e("BrowserAutomationService: Unexpected error during go back: ${e.message}", e, tag = "BrowserAutomationService")
+            }
+        }
+    }
+
+    suspend fun goForward() = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (!::page.isInitialized) {
+                Napier.e("BrowserAutomationService: Page is not initialized. Cannot go forward.", tag = "BrowserAutomationService")
+                return@withContext
+            }
+            Napier.i { "BrowserAutomationService: Going forward" }
+            try {
+                val response = page.goForward()
+                if (response == null) {
+                    Napier.w { "BrowserAutomationService: No next page to go forward to." }
+                } else {
+                    page.waitForLoadState()
+                    Napier.i { "BrowserAutomationService: Go forward completed." }
+                }
+            } catch (e: PlaywrightException) {
+                Napier.e("BrowserAutomationService: Go forward failed: ${e.message}", e, tag = "BrowserAutomationService")
+            } catch (e: Exception) {
+                Napier.e("BrowserAutomationService: Unexpected error during go forward: ${e.message}", e, tag = "BrowserAutomationService")
+            }
+        }
+    }
+
+    private suspend fun findVisibleElement(selectors: List<String>): Locator? = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (!::page.isInitialized) {
+                Napier.e("BrowserAutomationService: Page is not initialized. Cannot find element.", tag = "BrowserAutomationService")
+                return@withContext null
+            }
+            for (selector in selectors) {
+                val locator = page.locator(selector)
+                if (locator.count() > 0 && locator.first().isVisible) {
+                    Napier.i { "'$selector' 선택자로 요소를 찾았습니다."}
+                    return@withContext locator
+                }
+            }
+            Napier.w { "No visible element found for selectors: $selectors" }
+            return@withContext null
+        }
+    }
+
+    suspend fun clickElement(selector: String) = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (!::page.isInitialized) {
+                Napier.e("BrowserAutomationService: Page is not initialized. Cannot click element: $selector", tag = "BrowserAutomationService")
+                return@withContext
+            }
+            try {
+                val locator = page.locator(selector)
+                if (locator.count() > 0 && locator.first().isVisible) {
+                    locator.first().click()
+                    Napier.i { "Clicked element with selector: $selector" }
+                } else {
+                    Napier.w { "Element with selector $selector not found or not visible for clicking." }
+                }
+            } catch (e: PlaywrightException) {
+                Napier.e("Failed to click element $selector: ${e.message}", e, tag = "BrowserAutomationService")
+            } catch (e: Exception) {
+                Napier.e("Unexpected error clicking element $selector: ${e.message}", e, tag = "BrowserAutomationService")
+            }
+        }
+    }
+
+    suspend fun typeText(selector: String, text: String) = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (!::page.isInitialized) {
+                Napier.e("BrowserAutomationService: Page is not initialized. Cannot type text into element: $selector", tag = "BrowserAutomationService")
+                return@withContext
+            }
+            try {
+                val locator = page.locator(selector)
+                if (locator.count() > 0 && locator.first().isVisible) {
+                    locator.first().fill(text)
+                    Napier.i { "Typed text '$text' into element with selector: $selector" }
+                } else {
+                    Napier.w { "Element with selector $selector not found or not visible for typing." }
+                }
+            } catch (e: PlaywrightException) {
+                Napier.e("Failed to type text into element $selector: ${e.message}", e, tag = "BrowserAutomationService")
+            } catch (e: Exception) {
+                Napier.e("Unexpected error typing text into element $selector: ${e.message}", e, tag = "BrowserAutomationService")
+            }
+        }
+    }
+}


### PR DESCRIPTION
- 데스크톱 앱에서 Playwright으로 브라우저 띄우고 조작하는 Bridge, Service 생성 및 구현

# 구체적인 작업 내역
**1. BrowserAutomationService 구현**
- 초기화, 종료 메서드 구현 및 Application 실행 시 실행하도록 작성
- navigate, goForward, goBack 함수 구현
    - response == null 체크로 이동할 페이지가 없을 때 실행 방지
- 페이지 로드 안정성을 위해 page.waitForLoadState() 추가
- 프로젝트 빌드 후 navigate 관련 커맨드 실행 시 Playwright 내부 동작과 충돌이 일어나는 것 같아 suspend와 mutex 키워드를 추가해 한 번의 하나의 코루틴만 접근할 수 있도록 작성
    - 싱글톤 객체인 공유 자원 보호, Playwright 작업 안정성 확보
    - 받았던 에러 내용 : 
```
Exception in thread "DefaultDispatcher-worker-10" com.microsoft.playwright.PlaywrightException: Object doesn't exist: request@727a7f908587c81247042d9c123eff82
        at com.microsoft.playwright.impl.Connection.getExistingObject(Connection.java:192)
        at //이하 생략
```

**2. BrowserCommand sealed class 정의**
- 휴먼 에러를 방지하기 위해 Serializable 어노테이션을 추가해 직렬화/역직렬화가 가능한 sealed class 도입

**3. expect/actual 및 브리지 패턴을 사용한 브라우저 조작 구현**
- BrowserAutomation을 shared에서 expect로 구현한 상태로, 각 플랫폼에 맞는 웹 조작 함수를 구현하기 위해 선택
- BrowserAutomationActual에서 실제 동작 구현

**4. BrowserControlWebSocketClient 관련 수정**
- BrowserCommand로의 역직렬화를 위해 json.decodeFromString() 사용
- map을 mapNotNull로 변경해 안정성 확보

# 테스트 방법
https://github.com/user-attachments/assets/ee95991b-09bc-4fed-8dd4-a527ab3ec37d
1. 컨트롤러가 구현된 vowser-backend 실행
2. ./gradlew :desktopApp:run를 통해 데스크탑 앱 빌드 및 실행
3. 현재로서는 음성 인식 기능이 적용되어 있지 않으므로, curl을 사용하여 api 호출 (동영상 참고)
