### PR TITLE
Fix: 브라우저 자동화 클릭 실패 시 스마트 네비게이션 구현 및 하이라이팅 수정

### DIFF
--- a/shared/src/commonMain/kotlin/com/vowser/client/ui/graph/GraphCanvas.kt
+++ b/shared/src/commonMain/kotlin/com/vowser/client/ui/graph/GraphCanvas.kt
@@ -135,7 +135,11 @@ private fun DrawScope.drawUltraModernEdges(
         val toNode = nodeMap[edge.to]
 
         if (fromNode != null && toNode != null) {
-            val isHighlighted = highlightedPath.contains(fromNode.id) && highlightedPath.contains(toNode.id)
+            val isHighlighted = if (highlightedPath.size > 1) {
+                val fromIndex = highlightedPath.indexOf(fromNode.id)
+                val toIndex = highlightedPath.indexOf(toNode.id)
+                fromIndex >= 0 && toIndex >= 0 && abs(fromIndex - toIndex) == 1
+            } else false
 
             val startPos = Offset(fromNode.x * scale + offset.x, fromNode.y * scale + offset.y)
             val endPos = Offset(toNode.x * scale + offset.x, toNode.y * scale + offset.y)

--- a/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/BrowserActions.kt
+++ b/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/BrowserActions.kt
@@ -21,9 +21,9 @@ class BrowserActions(private val browserAutomationService: BrowserAutomationServ
         delayRandomly()
     }
 
-    suspend fun click(selector: String) {
+    suspend fun click(selector: String): Boolean {
         delayRandomly()
-        browserAutomationService.hoverAndClickElement(selector)
+        return browserAutomationService.hoverAndClickElement(selector)
     }
 
     suspend fun type(selector: String, text: String) {

--- a/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/NavigationActionExecutor.kt
+++ b/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/NavigationActionExecutor.kt
@@ -4,36 +4,62 @@ import com.vowser.client.websocket.dto.NavigationStep
 import io.github.aakira.napier.Napier
 
 interface NavigationActionExecutor {
-    suspend fun execute(browserActions: BrowserActions, step: NavigationStep)
+    suspend fun execute(browserActions: BrowserActions, step: NavigationStep): Boolean
 }
 
 class NavigateActionExecutor : NavigationActionExecutor {
-    override suspend fun execute(browserActions: BrowserActions, step: NavigationStep) {
-        browserActions.navigate(step.url)
+    override suspend fun execute(browserActions: BrowserActions, step: NavigationStep): Boolean {
+        return try {
+            browserActions.navigate(step.url)
+            true
+        } catch (e: Exception) {
+            Napier.e("Navigate action failed: ${e.message}")
+            false
+        }
     }
 }
 
 class ClickActionExecutor : NavigationActionExecutor {
-    override suspend fun execute(browserActions: BrowserActions, step: NavigationStep) {
-        step.selector?.let { selector ->
-            browserActions.click(selector)
-        } ?: Napier.e("Selector is null for click action.")
+    override suspend fun execute(browserActions: BrowserActions, step: NavigationStep): Boolean {
+        return step.selector?.let { selector ->
+            try {
+                browserActions.click(selector)
+            } catch (e: Exception) {
+                Napier.e("Click action failed: ${e.message}")
+                false
+            }
+        } ?: run {
+            Napier.e("Selector is null for click action.")
+            false
+        }
     }
 }
 
 class TypeActionExecutor : NavigationActionExecutor {
-    override suspend fun execute(browserActions: BrowserActions, step: NavigationStep) {
-        step.selector?.let { selector ->
-            val textToType = step.htmlAttributes?.get("value") ?: step.htmlAttributes?.get("text") ?: ""
-            browserActions.type(selector, textToType)
-        } ?: Napier.e("Selector is null for type action.")
+    override suspend fun execute(browserActions: BrowserActions, step: NavigationStep): Boolean {
+        return step.selector?.let { selector ->
+            try {
+                val textToType = step.htmlAttributes?.get("value") ?: step.htmlAttributes?.get("text") ?: ""
+                browserActions.type(selector, textToType)
+                true
+            } catch (e: Exception) {
+                Napier.e("Type action failed: ${e.message}")
+                false
+            }
+        } ?: run {
+            Napier.e("Selector is null for type action.")
+            false
+        }
     }
 }
 
 class SubmitActionExecutor : NavigationActionExecutor {
-    override suspend fun execute(browserActions: BrowserActions, step: NavigationStep) {
-        step.selector?.let { selector ->
+    override suspend fun execute(browserActions: BrowserActions, step: NavigationStep): Boolean {
+        return step.selector?.let { selector ->
             ClickActionExecutor().execute(browserActions, step)
-        } ?: Napier.e("Selector is null for submit action.")
+        } ?: run {
+            Napier.e("Selector is null for submit action.")
+            false
+        }
     }
 }


### PR DESCRIPTION
 ## 작업 개요
  기존 브라우저 자동화 시스템은 클릭 액션이 실패할 경우 해당 스텝을 건너뛰고 다음 스텝으로 진행하여, 사용자가 의도한 웹사이트에 도달하지 못하는 문제가 있었습니다.

  예를 들어 "뉴스 보여줘" 명령 시 네이버 메인 페이지에서 뉴스 링크 클릭이 실패하면, 네이버 메인 페이지에 머물러 있게 되어 사용자 경험이 저하되는 상황이 발생했습니다.

  이를 해결하기 위해 클릭 실패 감지 시스템과 스마트 폴백 네비게이션 기능을 구현하여, 첫 번째 웹사이트 전환에서 클릭이 실패할 경우 해당 웹사이트로 직접 이동하도록 개선했습니다.

  ## 주요 변경 사항

  ### 1. 액션 실행 결과 감지 시스템 구현
  - `NavigationActionExecutor` 인터페이스에 Boolean 반환값 추가하여 성공/실패 상태 전달
  - `BrowserAutomationService`의 `hoverAndClickElement` 메서드가 요소 발견 여부에 따라 true/false 반환
  - 기존 예외 기반 처리에서 명시적 결과 반환 방식으로 변경

  ### 2. 스마트 폴백 네비게이션 로직
  - 클릭 실패 시 다음 스텝의 URL을 확인하여 도메인 변경이 감지되면 해당 URL로 직접 이동
  - `hasNavigatedToFirstWebsite` 플래그를 통해 첫 번째 웹사이트 전환에서만 폴백 실행
  - 이후 클릭 실패는 기존대로 건너뛰어 과도한 네비게이션 방지

  ### 3. 도메인 변경 감지 개선
  - `isDifferentDomain()` 메서드로 현재 URL과 다음 스텝 URL의 도메인 비교
  - 서브도메인 전환(예: naver.com → news.naver.com)도 정확히 감지

 ### 4.하이라이팅 수정
 - 하이라이팅 구현이 첫번째 웹사이트까지 경로가 보이도록 수정했습니다.
 
<img width="795" height="594" alt="Screenshot 2025-08-20 at 5 20 24 PM" src="https://github.com/user-attachments/assets/7ac009f7-1dbb-4ef2-80c4-ca0249d08de6" />


  ## 동작 예시
  **"뉴스 보여줘" 시나리오:**
  1. naver.com 이동 ✅
  2. 뉴스 링크 클릭 시도 → 실패 ❌
  3. **자동으로 news.naver.com 이동** ✅ (새로 추가된 기능)
  4. 이후 클릭 실패 시에는 더 이상 자동 이동하지 않음

  ## 테스트 결과
  로그 분석 결과 다음과 같이 완벽하게 동작함을 확인:
  - 클릭 성공 시: 정상 진행
  - 첫 번째 웹사이트 전환에서 클릭 실패 시: 자동 네비게이션 실행
  - 이후 클릭 실패 시: 자동 네비게이션하지 않음

  ## 파일 변경 사항
  - `NavigationActionExecutor.kt`: 인터페이스에 Boolean 반환값 추가
  - `BrowserAutomationService.kt`: 클릭 결과 감지 로직 구현
  - `BrowserActions.kt`: 결과 전달 메서드 수정
  - `BrowserAutomationBridgeActual.kt`: 스마트 폴백 네비게이션 로직 구현