### PR TITLE
Feat: STT 모드 선택 UI 추가 및 WebSocket 로그 정리

### DIFF
--- a/shared/src/commonMain/kotlin/App.kt
+++ b/shared/src/commonMain/kotlin/App.kt
@@ -35,6 +35,9 @@ fun App() {
     // 음성 녹음 상태 구독
     val isRecording by viewModel.isRecording.collectAsState()
     val recordingStatus by viewModel.recordingStatus.collectAsState()
+
+    // STT 모드 상태 구독
+    val selectedSttModes by viewModel.selectedSttModes.collectAsState()
     
     // 그래프 데이터 구독
     val currentGraphData by viewModel.currentGraphData.collectAsState()
@@ -74,7 +77,8 @@ fun App() {
                     contributionStatus = contributionStatus,
                     contributionStepCount = contributionStepCount,
                     contributionTask = contributionTask,
-                    onModeToggle = { 
+                    selectedSttModes = selectedSttModes,
+                    onModeToggle = {
                         isContributionMode = !isContributionMode
                         if (isContributionMode) {
                             viewModel.startContribution(ContributionConstants.DEFAULT_TASK_NAME)
@@ -85,12 +89,13 @@ fun App() {
                     },
                     onScreenChange = { currentScreen = it },
                     onReconnect = { viewModel.reconnect() },
-                    onSendToolCall = { toolName, args -> 
+                    onSendToolCall = { toolName, args ->
                         viewModel.sendToolCall(toolName, args)
                     },
                     onToggleRecording = { viewModel.toggleRecording() },
                     onRefreshGraph = { viewModel.refreshGraph() },
-                    onClearStatusHistory = { viewModel.clearStatusHistory() }
+                    onClearStatusHistory = { viewModel.clearStatusHistory() },
+                    onToggleSttMode = { modeId -> viewModel.toggleSttMode(modeId) }
                 )
             }
             AppScreen.SETTINGS -> {

--- a/shared/src/commonMain/kotlin/com/vowser/client/data/SpeechRepository.kt
+++ b/shared/src/commonMain/kotlin/com/vowser/client/data/SpeechRepository.kt
@@ -22,11 +22,15 @@ class SpeechRepository(private val httpClient: HttpClient? = null) {
         }
     }
 
-    suspend fun transcribeAudio(audioFileBytes: ByteArray, sessionId: String): Result<String> {
+    suspend fun transcribeAudio(
+        audioFileBytes: ByteArray,
+        sessionId: String,
+        selectedModes: Set<String> = setOf("general")
+    ): Result<String> {
         return try {
             val backendUrl = "http://localhost:8080/api/v1/speech/transcribe"
-            
-            Napier.i("Sending audio file to backend. Size: ${audioFileBytes.size} bytes, SessionId: $sessionId", tag = "SpeechRepository")
+
+            Napier.i("Sending audio file to backend. Size: ${audioFileBytes.size} bytes, SessionId: $sessionId, Modes: $selectedModes", tag = "SpeechRepository")
 
             val response: HttpResponse = client.post(backendUrl) {
                 setBody(MultiPartFormDataContent(
@@ -36,6 +40,10 @@ class SpeechRepository(private val httpClient: HttpClient? = null) {
                             append(HttpHeaders.ContentDisposition, "filename=\"recording.wav\"")
                         })
                         append("sessionId", sessionId)
+                        append("enableGeneralMode", selectedModes.contains("general").toString())
+                        append("enableNumberMode", selectedModes.contains("number").toString())
+                        append("enableAlphabetMode", selectedModes.contains("alphabet").toString())
+                        append("enableSnippetMode", selectedModes.contains("snippet").toString())
                     }
                 ))
             }

--- a/shared/src/commonMain/kotlin/com/vowser/client/ui/components/SttModeSelector.kt
+++ b/shared/src/commonMain/kotlin/com/vowser/client/ui/components/SttModeSelector.kt
@@ -1,0 +1,145 @@
+package com.vowser.client.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vowser.client.ui.theme.AppTheme
+
+/**
+ * STT 모드 정보
+ */
+data class SttMode(
+    val id: String,
+    val name: String,
+    val description: String,
+    val iconEmoji: String,
+    val isDefault: Boolean = false
+)
+
+/**
+ * STT 모드 선택 UI 컴포넌트
+ */
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun SttModeSelector(
+    selectedModes: Set<String>,
+    onModeToggle: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    isVisible: Boolean = true
+) {
+    val availableModes = listOf(
+        SttMode(
+            id = "general",
+            name = "기본",
+            description = "일반 음성 인식",
+            iconEmoji = "\uD83D\uDD35",
+            isDefault = true
+        ),
+        SttMode(
+            id = "number",
+            name = "숫자",
+            description = "숫자 인식 최적화",
+            iconEmoji = "\uD83D\uDFE2",
+        ),
+        SttMode(
+            id = "alphabet",
+            name = "알파벳",
+            description = "알파벳 인식 최적화",
+            iconEmoji = "\uD83D\uDFE1",
+        ),
+        SttMode(
+            id = "snippet",
+            name = "스니펫",
+            description = "코드/명령어 인식",
+            iconEmoji = "\uD83D\uDFE3",
+        )
+    )
+
+    if (isVisible) {
+        Card(
+            modifier = modifier.fillMaxWidth(),
+            elevation = AppTheme.Dimensions.cardElevationLow,
+            backgroundColor = MaterialTheme.colors.surface,
+            shape = RoundedCornerShape(8.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = AppTheme.Dimensions.paddingMedium, vertical = AppTheme.Dimensions.paddingSmall),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(AppTheme.Dimensions.paddingSmall)
+            ) {
+                Text(
+                    text = "STT:",
+                    style = MaterialTheme.typography.body2.copy(
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 14.sp
+                    ),
+                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.8f)
+                )
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.weight(1f)
+                ) {
+                    availableModes.forEach { mode ->
+                        SttModeChip(
+                            mode = mode,
+                            isSelected = selectedModes.contains(mode.id),
+                            onToggle = { onModeToggle(mode.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * STT 모드 선택 칩
+ */
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun SttModeChip(
+    mode: SttMode,
+    isSelected: Boolean,
+    onToggle: () -> Unit
+) {
+    val contentColor = if (isSelected) {
+        MaterialTheme.colors.primary
+    } else {
+        MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+    }
+
+    Row(
+        modifier = Modifier
+            .clickable { onToggle() }
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Text(
+            text = mode.iconEmoji,
+            fontSize = 14.sp,
+            color = contentColor
+        )
+
+        Text(
+            text = mode.name,
+            style = MaterialTheme.typography.caption.copy(
+                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                fontSize = 13.sp
+            ),
+            color = contentColor
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/vowser/client/ui/screens/GraphScreen.kt
+++ b/shared/src/commonMain/kotlin/com/vowser/client/ui/screens/GraphScreen.kt
@@ -27,6 +27,7 @@ import com.vowser.client.ui.error.ErrorState
 import com.vowser.client.ui.error.SmartLoadingIndicator
 import com.vowser.client.ui.components.AppBar
 import com.vowser.client.ui.components.StatisticsPanel
+import com.vowser.client.ui.components.SttModeSelector
 import com.vowser.client.ui.theme.AppTheme
 import com.vowser.client.visualization.GraphVisualizationData
 import com.vowser.client.StatusLogEntry
@@ -50,6 +51,7 @@ fun GraphScreen(
     contributionStatus: ContributionStatus,
     contributionStepCount: Int,
     contributionTask: String,
+    selectedSttModes: Set<String>,
     onModeToggle: () -> Unit,
     onScreenChange: (AppScreen) -> Unit,
     onReconnect: () -> Unit,
@@ -57,6 +59,7 @@ fun GraphScreen(
     onToggleRecording: () -> Unit,
     onRefreshGraph: () -> Unit,
     onClearStatusHistory: () -> Unit,
+    onToggleSttMode: (String) -> Unit,
 ) {
     // 그래프 상태
     var selectedPath by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -136,10 +139,12 @@ fun GraphScreen(
                     statusHistory = statusHistory,
                     isDeveloperMode = isDeveloperMode,
                     receivedMessage = currentVoiceTest?.voiceCommand ?: receivedMessage,
+                    selectedSttModes = selectedSttModes,
                     onToggleRecording = onToggleRecording,
                     onModeToggle = onModeToggle,
                     onReconnect = onReconnect,
                     onClearStatusHistory = onClearStatusHistory,
+                    onToggleSttMode = onToggleSttMode,
                     onTestCommand = {
                         showGraphView = true  // 테스트 실행 시 그래프 뷰로 전환
                         // 새로운 날씨 검색 결과 모의 테스트 데이터
@@ -275,12 +280,14 @@ private fun EmptyStateUI(
     statusHistory: List<StatusLogEntry>,
     isDeveloperMode: Boolean,
     receivedMessage: String,
+    selectedSttModes: Set<String>,
     onToggleRecording: () -> Unit,
     onModeToggle: () -> Unit,
     onReconnect: () -> Unit,
     onClearStatusHistory: () -> Unit,
     onTestCommand: () -> Unit,
     onShowGraph: () -> Unit,
+    onToggleSttMode: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
@@ -385,6 +392,14 @@ private fun EmptyStateUI(
                 Text("Clear")
             }
         }
+
+        // STT 모드 선택기
+        SttModeSelector(
+            selectedModes = selectedSttModes,
+            onModeToggle = onToggleSttMode,
+            isVisible = !isRecording,
+            modifier = Modifier.fillMaxWidth()
+        )
 
         // 기여 모드 UI
         if (isContributionMode) {

--- a/shared/src/commonMain/kotlin/com/vowser/client/websocket/BrowserControlWebSocketClient.kt
+++ b/shared/src/commonMain/kotlin/com/vowser/client/websocket/BrowserControlWebSocketClient.kt
@@ -190,7 +190,11 @@ class BrowserControlWebSocketClient {
                         }
                     }
                 } catch (e: Exception) {
-                    Napier.e("Failed to parse or execute command from message: $messageString. Error: ${e.message}", e, tag = "VowserSocketClient")
+                    if (messageString.contains("연결되었습니다") || messageString.contains("error\":false")) {
+                        Napier.i("Received welcome or status message (ignored): $messageString", tag = "VowserSocketClient")
+                    } else {
+                        Napier.e("Failed to parse or execute command from message: $messageString. Error: ${e.message}", e, tag = "VowserSocketClient")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 작업 개요
데스크톱 클라이언트에 **STT 모드 선택기(칩 UI)**를 추가하고, WebSocket 수신 초기 메시지에 대한 **불필요한 에러 로그를 Info로 정리**했습니다.

## 주요 변경 사항
- **shared/src/commonMain/kotlin/com/vowser/client/ui/components/SttModeSelector.kt**
  - `SttMode` 데이터 모델 및 칩 기반 선택 UI 컴포저블 추가
  - 지원 모드: `general`(기본), `number`, `alphabet`, `snippet`
  - `selectedModes: Set<String>`, `onModeToggle(modeId: String)` 콜백 제공
  - 녹음 중에는 숨김 처리 가능(`isVisible`)

- **shared/src/commonMain/kotlin/com/vowser/client/ui/screens/GraphScreen.kt** 
  - `selectedSttModes: Set<String>` 전달 및 EmptyState 영역에 **SttModeSelector** 표시
  - `onToggleSttMode(modeId: String)` 콜백 연결
  - 녹음 중(`isRecording = true`)에는 선택기 비노출

- **shared/src/commonMain/kotlin/com/vowser/client/websocket/BrowserControlWebSocketClient.kt**
  - “연결되었습니다”, `error":false` 등 **웰컴/상태 메시지는 Info 로그로 처리**, 파싱 실패 에러 노이즈 감소

## 호환성 / 마이그레이션
- `GraphScreen` 및 내부 `EmptyStateUI` 시그니처에 **`selectedSttModes`, `onToggleSttMode`**가 추가되었습니다.
  - 기존 호출부는 아래처럼 상태와 콜백을 넘겨주세요.
  ```kotlin
  val selectedSttModes = remember { mutableStateOf(setOf("general")) }
  GraphScreen(
      /* ... */,
      selectedSttModes = selectedSttModes.value,
      onToggleSttMode = { id ->
          selectedSttModes.value =
              if (selectedSttModes.value.contains(id))
                  selectedSttModes.value - id
              else
                  selectedSttModes.value + id
      }
  )

### 화면
- 화면 ui 교체가 필요한 경우 수정하겠습니다(text와 아이콘 수정 예정).
- 4가지 모드 중 반드시 한가지는 선택해야 함
- 현재 가능한 선택(숫자모드와 기본모드) 
<img width="800" height="596" alt="Screenshot 2025-09-16 at 4 04 41 AM" src="https://github.com/user-attachments/assets/efdde24a-4970-4caf-a14a-c2eb39afe916" />
