### PR TITLE
Refactor: 대기 방식 수정, 에러 처리 최적화 및 에러 다이얼로그 추가

### DIFF
--- a/shared/src/commonMain/kotlin/App.kt
+++ b/shared/src/commonMain/kotlin/App.kt
@@ -65,6 +65,7 @@ fun App() {
         when (currentScreen) {
             AppScreen.GRAPH -> {
                 GraphScreen(
+                    appViewModel = viewModel,
                     navigationProcessor = navigationProcessor,
                     isContributionMode = isContributionMode,
                     isLoading = isLoading || graphLoading,

--- a/shared/src/commonMain/kotlin/com/vowser/client/exception/ExceptionHandler.kt
+++ b/shared/src/commonMain/kotlin/com/vowser/client/exception/ExceptionHandler.kt
@@ -1,0 +1,273 @@
+package com.vowser.client.exception
+
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlin.math.min
+import kotlin.math.pow
+
+/**
+ * 예외 처리, 복구
+ */
+class ExceptionHandler(
+    private val coroutineScope: CoroutineScope,
+    private val isDevelopmentMode: Boolean = false
+) {
+    companion object {
+        private const val TAG = "ExceptionHandler"
+    }
+
+    // 다이얼로그 표시 상태
+    private val _dialogState = MutableStateFlow<DialogState>(DialogState.Hidden)
+    val dialogState: StateFlow<DialogState> = _dialogState.asStateFlow()
+
+    // 현재 처리 중인 복구 작업들
+    private val activeRecoveries = mutableMapOf<String, RecoveryJob>()
+
+    /**
+     * 예외 처리, 복구 전략 실행
+     */
+    fun handleException(
+        exception: Throwable,
+        context: String = "",
+        onRecovery: suspend () -> Unit = {}
+    ) {
+        val vowserException = convertToVowserException(exception, context)
+
+        logException(vowserException, context)
+
+        val strategy = ExceptionRecoveryStrategies.getStrategy(vowserException)
+
+        if (strategy.autoRecovery && vowserException.isRetryable) {
+            executeAutoRecovery(vowserException, strategy, onRecovery)
+        } else if (strategy.showUserDialog) {
+            showUserDialog(vowserException, onRecovery)
+        }
+    }
+
+    /**
+     * 자동 복구
+     */
+    private fun executeAutoRecovery(
+        exception: VowserException,
+        strategy: ErrorRecoveryStrategy,
+        onRecovery: suspend () -> Unit
+    ) {
+        val recoveryId = "${exception.errorCode}_${Clock.System.now().toEpochMilliseconds()}"
+
+        coroutineScope.launch {
+            var attempt = 0
+            var success = false
+
+            while (attempt <= strategy.maxRetries && !success) {
+                if (attempt > 0) {
+                    val delayMs = calculateDelayMs(attempt - 1, strategy)
+                    Napier.i("Retrying ${exception.errorCode} after ${delayMs}ms (attempt $attempt/${strategy.maxRetries})", tag = TAG)
+                    delay(delayMs)
+                }
+
+                try {
+                    onRecovery()
+                    success = true
+                    Napier.i("Auto recovery succeeded for ${exception.errorCode} after $attempt attempts", tag = TAG)
+                } catch (e: Exception) {
+                    attempt++
+                    Napier.w("Auto recovery attempt $attempt failed for ${exception.errorCode}: ${e.message}", tag = TAG)
+                }
+            }
+
+            if (!success && strategy.showUserDialog) {
+                showUserDialog(exception, onRecovery)
+            }
+
+            activeRecoveries.remove(recoveryId)
+        }
+
+        activeRecoveries[recoveryId] = RecoveryJob(recoveryId, exception.errorCode)
+    }
+
+    /**
+     * 사용자 다이얼로그 표시
+     */
+    private fun showUserDialog(
+        exception: VowserException,
+        onRecovery: suspend () -> Unit
+    ) {
+        val dialogState = when (exception) {
+            is NetworkException.ConnectionFailed -> {
+                DialogState.NetworkError(
+                    onRetry = {
+                        hideDialog()
+                        coroutineScope.launch { onRecovery() }
+                    }
+                )
+            }
+            is BrowserException -> {
+                DialogState.BrowserError(
+                    retryCount = 0,
+                    onRetry = {
+                        hideDialog()
+                        coroutineScope.launch { onRecovery() }
+                    },
+                    onAlternative = { hideDialog() },
+                    onCancel = { hideDialog() }
+                )
+            }
+            is ContributionException.DataTransmissionFailed -> {
+                DialogState.ContributionError(
+                    onRetry = {
+                        hideDialog()
+                        coroutineScope.launch { onRecovery() }
+                    },
+                    onLater = { hideDialog() },
+                    onGiveUp = { hideDialog() }
+                )
+            }
+            is BrowserException.BrowserCrash -> {
+                DialogState.PlaywrightRestart(
+                    onRestart = {
+                        hideDialog()
+                        coroutineScope.launch { onRecovery() }
+                    }
+                )
+            }
+            else -> {
+                DialogState.GenericError(
+                    title = "오류",
+                    message = exception.userMessage,
+                    onConfirm = { hideDialog() }
+                )
+            }
+        }
+
+        _dialogState.value = dialogState
+    }
+
+    /**
+     * 다이얼로그 숨기기
+     */
+    fun hideDialog() {
+        _dialogState.value = DialogState.Hidden
+    }
+
+    /**
+     * 일반 Exception을 VowserException으로 변환
+     */
+    private fun convertToVowserException(exception: Throwable, context: String): VowserException {
+        return when {
+            exception is VowserException -> exception
+
+            exception.message?.contains("connection", ignoreCase = true) == true -> {
+                NetworkException.ConnectionFailed(exception)
+            }
+
+            exception.message?.contains("timeout", ignoreCase = true) == true -> {
+                NetworkException.RequestTimeout(exception)
+            }
+
+            exception.message?.contains("playwright", ignoreCase = true) == true -> {
+                BrowserException.PlaywrightConnectionLost(exception)
+            }
+
+            exception.message?.contains("memory", ignoreCase = true) == true ||
+            exception.message?.contains("heap", ignoreCase = true) == true ||
+            exception::class.simpleName?.contains("OutOfMemory", ignoreCase = true) == true -> {
+                SystemException.OutOfMemory(exception)
+            }
+
+            context.contains("contribution", ignoreCase = true) -> {
+                ContributionException.DataTransmissionFailed(exception)
+            }
+
+            else -> {
+                SystemException.FileSystemError(
+                    operation = "unknown",
+                    cause = exception
+                )
+            }
+        }
+    }
+
+    /**
+     * 예외 로깅
+     */
+    private fun logException(exception: VowserException, context: String) {
+        val contextInfo = if (context.isNotEmpty()) " [Context: $context]" else ""
+
+        when (exception) {
+            is NetworkException -> {
+                Napier.w("Network Exception${contextInfo}: ${exception.message}", exception, tag = TAG)
+            }
+            is BrowserException -> {
+                Napier.e("Browser Exception${contextInfo}: ${exception.message}", exception, tag = TAG)
+            }
+            is ContributionException -> {
+                Napier.w("Contribution Exception${contextInfo}: ${exception.message}", exception, tag = TAG)
+            }
+            is SystemException -> {
+                Napier.e("System Exception${contextInfo}: ${exception.message}", exception, tag = TAG)
+            }
+        }
+
+        // 개발 모드에서는 더 상세한 정보 로깅
+        if (isDevelopmentMode) {
+            Napier.d("Exception details - ErrorCode: ${exception.errorCode}, Retryable: ${exception.isRetryable}", tag = TAG)
+        }
+    }
+
+    /**
+     * Exponential backoff로 지연 시간 계산
+     */
+    private fun calculateDelayMs(attempt: Int, strategy: ErrorRecoveryStrategy): Long {
+        val exponentialDelay = (strategy.retryDelayMs * strategy.backoffMultiplier.pow(attempt)).toLong()
+        return min(exponentialDelay, 30000L) // 최대 30초
+    }
+}
+
+/**
+ * 다이얼로그 상태
+ */
+sealed class DialogState {
+    object Hidden : DialogState()
+
+    data class NetworkError(
+        val onRetry: () -> Unit
+    ) : DialogState()
+
+    data class BrowserError(
+        val retryCount: Int,
+        val onRetry: () -> Unit,
+        val onAlternative: () -> Unit,
+        val onCancel: () -> Unit
+    ) : DialogState()
+
+    data class ContributionError(
+        val onRetry: () -> Unit,
+        val onLater: () -> Unit,
+        val onGiveUp: () -> Unit
+    ) : DialogState()
+
+    data class PlaywrightRestart(
+        val onRestart: () -> Unit
+    ) : DialogState()
+
+    data class GenericError(
+        val title: String,
+        val message: String,
+        val onConfirm: () -> Unit
+    ) : DialogState()
+}
+
+/**
+ * 복구 작업 정보
+ */
+private data class RecoveryJob(
+    val id: String,
+    val errorCode: String,
+    val startTime: Long = Clock.System.now().toEpochMilliseconds()
+)

--- a/shared/src/commonMain/kotlin/com/vowser/client/exception/VowserExceptions.kt
+++ b/shared/src/commonMain/kotlin/com/vowser/client/exception/VowserExceptions.kt
@@ -1,0 +1,215 @@
+package com.vowser.client.exception
+
+import kotlinx.serialization.Serializable
+
+/**
+ * 예외 계층 구조
+ */
+sealed class VowserException(
+    message: String,
+    cause: Throwable? = null,
+    val errorCode: String = "UNKNOWN_ERROR",
+    val userMessage: String = message,
+    val isRetryable: Boolean = false
+) : Exception(message, cause)
+
+/**
+ * 네트워크 관련 예외
+ */
+sealed class NetworkException(
+    message: String,
+    cause: Throwable? = null,
+    errorCode: String,
+    userMessage: String,
+    isRetryable: Boolean = true
+) : VowserException(message, cause, errorCode, userMessage, isRetryable) {
+
+    class ConnectionFailed(cause: Throwable? = null) : NetworkException(
+        message = "Network connection failed",
+        cause = cause,
+        errorCode = "NETWORK_CONNECTION_FAILED",
+        userMessage = "인터넷 연결을 확인해주세요"
+    )
+
+    class WebSocketDisconnected(cause: Throwable? = null) : NetworkException(
+        message = "WebSocket connection lost",
+        cause = cause,
+        errorCode = "WEBSOCKET_DISCONNECTED",
+        userMessage = "서버와 연결이 끊어졌습니다. 자동으로 재연결합니다.",
+        isRetryable = true
+    )
+
+    class RequestTimeout(cause: Throwable? = null) : NetworkException(
+        message = "Network request timeout",
+        cause = cause,
+        errorCode = "NETWORK_TIMEOUT",
+        userMessage = "요청 시간이 초과되었습니다"
+    )
+
+    class ServerError(val statusCode: Int, cause: Throwable? = null) : NetworkException(
+        message = "Server error: $statusCode",
+        cause = cause,
+        errorCode = "SERVER_ERROR_$statusCode",
+        userMessage = "서버에 일시적인 문제가 발생했습니다"
+    )
+}
+
+/**
+ * 브라우저 자동화 관련 예외
+ */
+sealed class BrowserException(
+    message: String,
+    cause: Throwable? = null,
+    errorCode: String,
+    userMessage: String,
+    isRetryable: Boolean = true
+) : VowserException(message, cause, errorCode, userMessage, isRetryable) {
+
+    class PlaywrightConnectionLost(cause: Throwable? = null) : BrowserException(
+        message = "Playwright connection lost",
+        cause = cause,
+        errorCode = "PLAYWRIGHT_CONNECTION_LOST",
+        userMessage = "브라우저와 연결이 끊어졌습니다"
+    )
+
+    class ElementNotFound(val selector: String, cause: Throwable? = null) : BrowserException(
+        message = "Element not found: $selector",
+        cause = cause,
+        errorCode = "ELEMENT_NOT_FOUND",
+        userMessage = "페이지에서 요소를 찾을 수 없습니다"
+    )
+
+    class PageLoadTimeout(val url: String, cause: Throwable? = null) : BrowserException(
+        message = "Page load timeout: $url",
+        cause = cause,
+        errorCode = "PAGE_LOAD_TIMEOUT",
+        userMessage = "페이지 로딩 시간이 초과되었습니다"
+    )
+
+    class BrowserCrash(cause: Throwable? = null) : BrowserException(
+        message = "Browser process crashed",
+        cause = cause,
+        errorCode = "BROWSER_CRASH",
+        userMessage = "브라우저에 문제가 발생했습니다",
+        isRetryable = false
+    )
+}
+
+/**
+ * 기여 모드 관련 예외
+ */
+sealed class ContributionException(
+    message: String,
+    cause: Throwable? = null,
+    errorCode: String,
+    userMessage: String,
+    isRetryable: Boolean = true
+) : VowserException(message, cause, errorCode, userMessage, isRetryable) {
+
+    class DataTransmissionFailed(cause: Throwable? = null) : ContributionException(
+        message = "Contribution data transmission failed",
+        cause = cause,
+        errorCode = "CONTRIBUTION_TRANSMISSION_FAILED",
+        userMessage = "기여 데이터 전송에 실패했습니다"
+    )
+
+    class InvalidContributionData(val reason: String, cause: Throwable? = null) : ContributionException(
+        message = "Invalid contribution data: $reason",
+        cause = cause,
+        errorCode = "INVALID_CONTRIBUTION_DATA",
+        userMessage = "기여 데이터가 올바르지 않습니다",
+        isRetryable = false
+    )
+
+    class SessionExpired(cause: Throwable? = null) : ContributionException(
+        message = "Contribution session expired",
+        cause = cause,
+        errorCode = "CONTRIBUTION_SESSION_EXPIRED",
+        userMessage = "기여 세션이 만료되었습니다",
+        isRetryable = false
+    )
+}
+
+/**
+ * 시스템 리소스 관련 예외
+ */
+sealed class SystemException(
+    message: String,
+    cause: Throwable? = null,
+    errorCode: String,
+    userMessage: String,
+    isRetryable: Boolean = false
+) : VowserException(message, cause, errorCode, userMessage, isRetryable) {
+
+    class OutOfMemory(cause: Throwable? = null) : SystemException(
+        message = "Out of memory",
+        cause = cause,
+        errorCode = "OUT_OF_MEMORY",
+        userMessage = "메모리가 부족합니다. 자동으로 정리합니다."
+    )
+
+    class FileSystemError(val operation: String, cause: Throwable? = null) : SystemException(
+        message = "File system error: $operation",
+        cause = cause,
+        errorCode = "FILE_SYSTEM_ERROR",
+        userMessage = "파일 시스템 오류가 발생했습니다"
+    )
+}
+
+/**
+ * 에러 복구 전략
+ */
+@Serializable
+data class ErrorRecoveryStrategy(
+    val maxRetries: Int = 3,
+    val retryDelayMs: Long = 1000L,
+    val backoffMultiplier: Double = 2.0,
+    val showUserDialog: Boolean = false,
+    val autoRecovery: Boolean = true
+)
+
+/**
+ * 예외별 복구 전략 매핑
+ */
+object ExceptionRecoveryStrategies {
+    private val strategies = mapOf(
+        NetworkException.ConnectionFailed::class to ErrorRecoveryStrategy(
+            maxRetries = 0,
+            showUserDialog = true,
+            autoRecovery = false
+        ),
+        NetworkException.WebSocketDisconnected::class to ErrorRecoveryStrategy(
+            maxRetries = Int.MAX_VALUE,
+            retryDelayMs = 0L, // 즉시 재연결
+            showUserDialog = false,
+            autoRecovery = true
+        ),
+        BrowserException.ElementNotFound::class to ErrorRecoveryStrategy(
+            maxRetries = 3,
+            retryDelayMs = 1000L,
+            backoffMultiplier = 2.0,
+            showUserDialog = true,
+            autoRecovery = true
+        ),
+        BrowserException.BrowserCrash::class to ErrorRecoveryStrategy(
+            maxRetries = 0,
+            showUserDialog = true,
+            autoRecovery = false
+        ),
+        ContributionException.DataTransmissionFailed::class to ErrorRecoveryStrategy(
+            maxRetries = 0,
+            showUserDialog = true,
+            autoRecovery = false
+        ),
+        SystemException.OutOfMemory::class to ErrorRecoveryStrategy(
+            maxRetries = 1,
+            retryDelayMs = 2000L,
+            showUserDialog = false,
+            autoRecovery = true
+        )
+    )
+
+    fun getStrategy(exception: VowserException): ErrorRecoveryStrategy {
+        return strategies[exception::class] ?: ErrorRecoveryStrategy()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/vowser/client/ui/components/ErrorDialog.kt
+++ b/shared/src/commonMain/kotlin/com/vowser/client/ui/components/ErrorDialog.kt
@@ -1,0 +1,266 @@
+package com.vowser.client.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+/**
+ * 표준화된 에러/확인 다이얼로그 컴포넌트
+ */
+@Composable
+fun ErrorDialog(
+    visible: Boolean,
+    title: String,
+    message: String,
+    type: ErrorDialogType = ErrorDialogType.ERROR,
+    positiveButtonText: String = "확인",
+    negativeButtonText: String? = null,
+    onPositiveClick: () -> Unit,
+    onNegativeClick: (() -> Unit)? = null,
+    onDismiss: () -> Unit = {}
+) {
+    if (visible) {
+        Dialog(
+            onDismissRequest = onDismiss,
+            properties = DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = false
+            )
+        ) {
+            ErrorDialogContent(
+                title = title,
+                message = message,
+                type = type,
+                positiveButtonText = positiveButtonText,
+                negativeButtonText = negativeButtonText,
+                onPositiveClick = onPositiveClick,
+                onNegativeClick = onNegativeClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun ErrorDialogContent(
+    title: String,
+    message: String,
+    type: ErrorDialogType,
+    positiveButtonText: String,
+    negativeButtonText: String?,
+    onPositiveClick: () -> Unit,
+    onNegativeClick: (() -> Unit)?
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth(0.85f)
+            .wrapContentHeight(),
+        shape = RoundedCornerShape(16.dp),
+        elevation = 8.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .background(Color.White)
+                .padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // 아이콘
+            Icon(
+                imageVector = type.icon,
+                contentDescription = null,
+                tint = type.color,
+                modifier = Modifier.size(48.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 제목
+            Text(
+                text = title,
+                style = MaterialTheme.typography.h6.copy(
+                    fontWeight = FontWeight.Bold,
+                    color = Color.Black
+                ),
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 메시지
+            Text(
+                text = message,
+                style = MaterialTheme.typography.body1.copy(
+                    color = Color.Gray,
+                    lineHeight = 20.sp
+                ),
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 버튼들
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = if (negativeButtonText != null) {
+                    Arrangement.SpaceEvenly
+                } else {
+                    Arrangement.Center
+                }
+            ) {
+                // 취소/아니오 버튼 (선택사항)
+                negativeButtonText?.let { buttonText ->
+                    Button(
+                        onClick = {
+                            onNegativeClick?.invoke()
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = Color.LightGray,
+                            contentColor = Color.DarkGray
+                        ),
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp)
+                            .clip(RoundedCornerShape(8.dp))
+                    ) {
+                        Text(
+                            text = buttonText,
+                            style = MaterialTheme.typography.button.copy(
+                                fontWeight = FontWeight.Medium
+                            )
+                        )
+                    }
+
+                    if (negativeButtonText != null) {
+                        Spacer(modifier = Modifier.width(12.dp))
+                    }
+                }
+
+                // 확인/예 버튼
+                Button(
+                    onClick = onPositiveClick,
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = type.color,
+                        contentColor = Color.White
+                    ),
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                ) {
+                    Text(
+                        text = positiveButtonText,
+                        style = MaterialTheme.typography.button.copy(
+                            fontWeight = FontWeight.Medium
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 다이얼로그 타입별 아이콘과 색상 정의
+ */
+enum class ErrorDialogType(
+    val icon: ImageVector,
+    val color: Color
+) {
+    ERROR(Icons.Default.Warning, Color(0xFFE53E3E)),
+    WARNING(Icons.Default.Warning, Color(0xFFFF8C00)),
+    INFO(Icons.Default.Info, Color(0xFF3182CE)),
+    QUESTION(Icons.Default.Info, Color(0xFF38A169))
+}
+
+/**
+ * 사전 정의된 다이얼로그들
+ */
+object StandardDialogs {
+
+    @Composable
+    fun NetworkError(
+        visible: Boolean,
+        onRetryClick: () -> Unit,
+        onDismiss: () -> Unit
+    ) {
+        ErrorDialog(
+            visible = visible,
+            title = "네트워크 오류",
+            message = "인터넷 연결을 확인해주세요.\n잠시 후 다시 시도해보시기 바랍니다.",
+            type = ErrorDialogType.ERROR,
+            positiveButtonText = "확인",
+            onPositiveClick = onRetryClick,
+            onDismiss = onDismiss
+        )
+    }
+
+    @Composable
+    fun BrowserRetryDialog(
+        visible: Boolean,
+        onRetryClick: () -> Unit,
+        onAlternativeClick: () -> Unit,
+        onCancelClick: () -> Unit
+    ) {
+        ErrorDialog(
+            visible = visible,
+            title = "브라우저 오류",
+            message = "브라우저 작업에 실패했습니다.\n계속 시도하시겠습니까?",
+            type = ErrorDialogType.WARNING,
+            positiveButtonText = "다시 시도",
+            negativeButtonText = "취소",
+            onPositiveClick = onRetryClick,
+            onNegativeClick = onCancelClick
+        )
+    }
+
+    @Composable
+    fun ContributionFailureDialog(
+        visible: Boolean,
+        onRetryClick: () -> Unit,
+        onLaterClick: () -> Unit,
+        onGiveupClick: () -> Unit
+    ) {
+        ErrorDialog(
+            visible = visible,
+            title = "기여 데이터 전송 실패",
+            message = "기여 데이터 전송에 실패했습니다.\n어떻게 하시겠습니까?",
+            type = ErrorDialogType.QUESTION,
+            positiveButtonText = "재시도",
+            negativeButtonText = "나중에",
+            onPositiveClick = onRetryClick,
+            onNegativeClick = onLaterClick
+        )
+    }
+
+    @Composable
+    fun PlaywrightRestartDialog(
+        visible: Boolean,
+        onRestartClick: () -> Unit,
+        onDismiss: () -> Unit
+    ) {
+        ErrorDialog(
+            visible = visible,
+            title = "브라우저 재시작 필요",
+            message = "브라우저에 문제가 발생했습니다.\n브라우저를 재시작하시겠습니까?",
+            type = ErrorDialogType.WARNING,
+            positiveButtonText = "재시작",
+            negativeButtonText = "취소",
+            onPositiveClick = onRestartClick,
+            onNegativeClick = onDismiss
+        )
+    }
+}

--- a/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/AdaptiveWaitManager.kt
+++ b/shared/src/desktopMain/kotlin/com/vowserclient/shared/browserautomation/AdaptiveWaitManager.kt
@@ -1,0 +1,200 @@
+package com.vowserclient.shared.browserautomation
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.PlaywrightException
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.delay
+
+/**
+ * 네트워크 상태와 페이지 로딩 상태에 따라 대기, 실행 여부를 결정
+ */
+object AdaptiveWaitManager {
+
+    private const val TAG = "AdaptiveWaitManager"
+
+    // 대기 설정
+    private const val MIN_TIMEOUT_MS = 2000.0
+    private const val MAX_TIMEOUT_MS = 15000.0
+    private const val BASE_TIMEOUT_MS = 5000.0
+
+    // 네트워크 상태 기반 대기 시간 계산
+    private fun calculateTimeout(page: Page): Double {
+        return try {
+            // 페이지 성능 메트릭 확인 시도
+            val networkState = checkNetworkState(page)
+            when (networkState) {
+                NetworkState.FAST -> MIN_TIMEOUT_MS
+                NetworkState.NORMAL -> BASE_TIMEOUT_MS
+                NetworkState.SLOW -> MAX_TIMEOUT_MS
+            }
+        } catch (e: Exception) {
+            Napier.w("Failed to check network state, using base timeout: ${e.message}", tag = TAG)
+            BASE_TIMEOUT_MS
+        }
+    }
+
+    private fun checkNetworkState(page: Page): NetworkState {
+        return try {
+            // 페이지 로딩 상태 확인
+            val isNetworkIdle = page.evaluate("""
+                () => {
+                    return document.readyState === 'complete' &&
+                           performance.timing.loadEventEnd > 0;
+                }
+            """) as Boolean
+
+            if (isNetworkIdle) {
+                NetworkState.FAST
+            } else {
+                // DOM에서 로딩 인디케이터 확인
+                val hasLoadingIndicators = page.evaluate("""
+                    () => {
+                        const loadingSelectors = [
+                            '[class*="loading"]',
+                            '[class*="spinner"]',
+                            '[class*="skeleton"]',
+                            '.loading-spinner',
+                            '.load-more'
+                        ];
+                        return loadingSelectors.some(selector =>
+                            document.querySelector(selector) !== null
+                        );
+                    }
+                """) as Boolean
+
+                if (hasLoadingIndicators) NetworkState.SLOW else NetworkState.NORMAL
+            }
+        } catch (e: Exception) {
+            Napier.d("Network state check failed, assuming normal: ${e.message}", tag = TAG)
+            NetworkState.NORMAL
+        }
+    }
+
+    /**
+     * 네트워크 상태에 따라 대기 시간 조정
+     */
+    suspend fun waitForElement(
+        locator: Locator,
+        page: Page,
+        description: String = "element"
+    ): Boolean {
+        val adaptiveTimeout = calculateTimeout(page)
+
+        Napier.d("Waiting for $description with adaptive timeout: ${adaptiveTimeout}ms", tag = TAG)
+
+        return try {
+            locator.first().waitFor(
+                Locator.WaitForOptions()
+                    .setTimeout(adaptiveTimeout)
+            )
+
+            // 추가 가시성 확인
+            val isVisible = locator.first().isVisible
+            if (isVisible) {
+                Napier.d("$description found and visible within ${adaptiveTimeout}ms", tag = TAG)
+            } else {
+                Napier.w("$description found but not visible after ${adaptiveTimeout}ms", tag = TAG)
+            }
+
+            isVisible
+        } catch (e: PlaywrightException) {
+            Napier.w("$description not found within ${adaptiveTimeout}ms: ${e.message}", tag = TAG)
+            false
+        }
+    }
+
+    /**
+     * 페이지 로딩이 완료될 때까지 대기
+     */
+    suspend fun waitForPageLoad(page: Page, description: String = "page") {
+        Napier.d("Waiting for $description load with adaptive approach", tag = TAG)
+
+        try {
+            // 기본 로드 상태 대기
+            page.waitForLoadState()
+
+            // 네트워크 유휴 상태까지 추가 대기
+            val networkState = checkNetworkState(page)
+            if (networkState == NetworkState.SLOW) {
+                Napier.d("Slow network detected, waiting for network idle", tag = TAG)
+                page.waitForLoadState()
+            }
+
+            // DOM 안정화 대기
+            waitForDomStable(page)
+
+            Napier.i("$description loading completed", tag = TAG)
+
+        } catch (e: Exception) {
+            Napier.w("Page load wait completed with warnings: ${e.message}", tag = TAG)
+        }
+    }
+
+    /**
+     * DOM이 안정화될 때까지 대기
+     */
+    private suspend fun waitForDomStable(page: Page, maxAttempts: Int = 5) {
+        var previousNodeCount = 0
+        var stableCount = 0
+
+        repeat(maxAttempts) { attempt ->
+            try {
+                val currentNodeCount = page.evaluate("() => document.getElementsByTagName('*').length") as Int
+
+                if (currentNodeCount == previousNodeCount) {
+                    stableCount++
+                    if (stableCount >= 2) {
+                        Napier.d("DOM stable after ${attempt + 1} checks", tag = TAG)
+                        return
+                    }
+                } else {
+                    stableCount = 0
+                }
+
+                previousNodeCount = currentNodeCount
+                delay(500)
+
+            } catch (e: Exception) {
+                Napier.d("DOM stability check failed: ${e.message}", tag = TAG)
+                return
+            }
+        }
+    }
+
+    /**
+     * 동적 콘텐츠 로딩 대기 (무한 스크롤, AJAX 등)
+     */
+    suspend fun waitForDynamicContent(
+        page: Page,
+        checkScript: String,
+        description: String = "dynamic content",
+        maxAttempts: Int = 10
+    ): Boolean {
+        Napier.d("Waiting for $description with dynamic checks", tag = TAG)
+
+        repeat(maxAttempts) { attempt ->
+            try {
+                val isReady = page.evaluate(checkScript) as Boolean
+                if (isReady) {
+                    Napier.i("$description ready after ${attempt + 1} attempts", tag = TAG)
+                    return true
+                }
+
+                // 점진적으로 대기 시간 증가
+                val delayMs = minOf(500 + (attempt * 200), 2000)
+                delay(delayMs.toLong())
+
+            } catch (e: Exception) {
+                Napier.w("Dynamic content check failed (attempt ${attempt + 1}): ${e.message}", tag = TAG)
+            }
+        }
+
+        Napier.w("$description not ready after $maxAttempts attempts", tag = TAG)
+        return false
+    }
+}
+
+private enum class NetworkState {
+    FAST, NORMAL, SLOW
+}


### PR DESCRIPTION
##  작업 개요
기존의 고정된 시간 후 동작이 아닌 웹 사이트가 로딩된 후 동작하도록 변경
예외 처리 중앙화
예외 발생 시 사용자가 어떻게 처리할지 정해야 하는 경우, ErrorDialog를 띄우도록 구현(임의 디자인)

## 주요 변경 사항

### 1.  대기 방식 수정
기존 동작 방식 : 2초 지나면 웹사이트가 로딩되었을 거라고 생각하고 동작
현재 동작 방식 : 돔 방식을 기반, API 상태를 기반으로 로딩된 경우 동작

### 2. 예외 처리 중앙화
- ExceptionHandler에서 예외 처리하도록 수정

### 3. ErrorDialog
<img width="603" height="410" alt="Screenshot 2025-09-26 at 16 57 28" src="https://github.com/user-attachments/assets/38daa37e-29ac-4c7f-ae02-54951d9f2172" />
<img width="469" height="330" alt="Screenshot 2025-09-26 at 16 58 05" src="https://github.com/user-attachments/assets/dc0e47c4-c695-4157-a2f0-84fe99502690" />
